### PR TITLE
Suggested corrections

### DIFF
--- a/data/roman_consuls_uris.tsv
+++ b/data/roman_consuls_uris.tsv
@@ -362,7 +362,7 @@ https://godot.date/id/EvrUhPtbnoSiYKWQcCczLA	L. Valerius Messalla (Messala) (App
 https://godot.date/id/ASAXcbk79mKh5THW9s2FMS	Q. Maecius Laetus II ; M. Munatius Sulla Cerialis (Cerealis)	215	215		
 https://godot.date/id/Qw6dvbJiPiiqnoytNMC7UV	P. Catius Sabinus II ; P. Cornelius Anullinus	216	216		
 https://godot.date/id/TWMbxx98qn83Y2apeTVaaT	C. Bruttius Praesens ; T. Messius Extricatus II	217	217		
-https://godot.date/id/d3MZGx9PN67Cqj998tqa26	Imp. Caesar M. Opellius Severus Macrinus Agustus "II" ; M. Oclatiniusventus "II"	218	218		
+https://godot.date/id/d3MZGx9PN67Cqj998tqa26	Imp. Caesar M. Opellius Severus Macrinus Augustus II ; M. Oclatinius Adventus II	218	218		
 https://godot.date/id/pkikcYzSRZsGRWUGJZRqMf	Imp. Caesar M. Aurelius Antoninus Augustus II ; Q. Tineius Sacerdos II	219	219		
 https://godot.date/id/TYLBYjXQLgXTfpnLfUtZ8c	Imp. Caesar M. Aurelius Antoninus Augustus III ; P. Valerius Comazon Eutychianus "II"	220	220		
 https://godot.date/id/JmHQP7gxBE8F7fnDMySMWj	C. Vettius Gratus Sabinianus ; M. Flavius Vituellius Seleucus	221	221	https://www.wikidata.org/wiki/Q745547	https://www.wikidata.org/wiki/Q252841


### PR DESCRIPTION
Code line 365. Agustus "II" to Augustus II and Oclatiniusventus "II" to Oclatinius Adventus II. This probably means that the table will be properly displayed.